### PR TITLE
Client: Closes #5 (cosicas tontas)

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -29,43 +29,43 @@ constexpr bool is_lvalue(T&&) noexcept
 	  return std::is_lvalue_reference<T>{};
 }
 
+void Client::pr_ids(void)
+{
+	std::cout << "Assigned ids for this Client are:" << std::endl;
+	for (const auto& i: r_ids_) {
+		std::cout << i << std::endl;
+	}
+}
+
 /*
  * Constructor para clientes:
  * @param size:  número de identificadores a guardar en el servido (tamaño de la tabla en el servidor)
  * @param port:  puerto de habilitado en el servidor
  * @param ip_addr: dirección IP del servidor
  */
-Client::Client(int size, std::string port_n, std::string ip_addr) : server_size{size} ,  port{port_n}, ip{ip_addr}
+Client::Client(int size, std::string port_n, std::string ip_addr) : server_size_{size} ,  port_{port_n}, ip_{ip_addr}
 {
 	// Initialize vectors with randomly assigned ids [1, 250], and names
-	r_ids.reserve(server_size);
-	generate_ids(r_ids);
+	r_ids_.reserve(server_size_);
 
-	for (std::vector<int>::size_type i = 0 ; i < r_ids.size(); ++i ) {
-		p_insert.emplace_back(std::make_pair(r_ids[i],
-						     names[i % names.size()]));
+	auto generate_ids = [&id = r_ids_]() {
+		for (size_t i = 1; i <= id.capacity(); ++i) {
+			id.emplace_back(i);
+		}
+		auto engine = std::default_random_engine();
+
+		std::shuffle(id.begin(), id.end(), engine);
+	};
+
+	generate_ids();
+
+
+	for (std::vector<int>::size_type i = 0 ; i < r_ids_.size(); ++i ) {
+		p_insert_.emplace_back(std::make_pair(r_ids_[i], names_[i %
+						     names_.size()]));
+
 	}
 }
-
-/*
- * generate_ids
- * Crea un vector de identificadores únicos y aleatoriamente ordenados
- * @param id: vector en el que se guardan los identificadores generados
- */
-void Client::generate_ids(std::vector<int>& id) noexcept
-{
-	auto cap = id.capacity();
-
-	for (size_t i = 1 ; i <= cap; ++i) {
-		id.emplace_back(i);
-	}
-	auto engine = std::default_random_engine();
-
-	std::shuffle(id.begin(), id.end(), engine);
-	/* http://stackoverflow.com/questions/26290316/difference-between-vectorbegin-and-stdbegin
-	 */
-}
-
 
 /*
  * connect
@@ -80,16 +80,16 @@ int Client::connect(void)
 
 	/* If a specific server IP has been given as input, use that.
 	 * Otherwise use localhost*/
-	Asio::tcp::resolver::query query(port);
+	Asio::tcp::resolver::query query(port_);
 
 	Asio::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 
 	boost::system::error_code ec;
 
-	current_socket.reset(new Asio::tcp::socket(io_service));
+	current_socket_.reset(new Asio::tcp::socket(io_service));
 
 	/* Connect to the server */
-	boost::asio::connect(*current_socket, endpoint_iterator, ec);
+	boost::asio::connect(*current_socket_, endpoint_iterator, ec);
 
 	if (ec == boost::asio::error::not_found) {
 		return 0;
@@ -104,8 +104,8 @@ int Client::connect(void)
 
 int Client::send(void)
 {
-	if (current_socket == nullptr) {
-		std::cerr << "current_socket == nullptr. Invalid socket" <<
+	if (current_socket_ == nullptr) {
+		std::cerr << "current_socket_ == nullptr. Invalid socket" <<
 			std::endl;
 		return -1;
 	}
@@ -115,7 +115,7 @@ int Client::send(void)
 	boost::asio::streambuf write_buffer;
 
 	boost::system::error_code err;
-	for (const auto& i : p_insert) {
+	for (const auto& i : p_insert_) {
 		std::cout << "sending element: " << std::to_string(i.first) << std::endl;
 
 		/* Write to server. */
@@ -130,14 +130,14 @@ int Client::send(void)
 		 * +----------------+-------------------------------------------+
 		 */
 		std::cout << "Writing: " << make_string(write_buffer) << std::endl;
-		auto bytes_transferred = boost::asio::write(*current_socket, write_buffer, err);
+		auto bytes_transferred = boost::asio::write(*current_socket_, write_buffer, err);
 		std::cout << "element sent: bytes:" << bytes_transferred << std::endl;
 		write_buffer.consume(bytes_transferred); // Remove data that was written.
 		auto ts = std::chrono::high_resolution_clock::now();
 
 		std::cout << "reading from server..." << std::endl;
 		/* We only read 1 char, 0 for OK, 1 for NOK */
-		bytes_transferred = boost::asio::read(*current_socket, read_buffer,
+		bytes_transferred = boost::asio::read(*current_socket_, read_buffer,
 				boost::asio::transfer_exactly(sizeof(char)));
 
 		/* read to int */
@@ -166,11 +166,11 @@ int Client::send(void)
 			res = -1;
 		}
 
-		t_lapse = te - ts;
+		t_lapse_ = te - ts;
 		/* http://www.cppsamples.com/common-tasks/measure-execution-time.html */
 
 		std::cout << "I sent user: " << i.second << " to the server."<< std::endl
-			<< "It replied: " <<   unsigned(resp) << std::endl << "It took " << t_lapse.count() << "ms" << std::endl;
+			<< "It replied: " <<   unsigned(resp) << std::endl << "It took " << t_lapse_.count() << "ms" << std::endl;
 
 		std::this_thread::sleep_for(std::chrono::seconds(U_SEC_SLEEP));
 	}

--- a/src/client/client.hpp
+++ b/src/client/client.hpp
@@ -18,22 +18,22 @@ public:
   Client(int size = SERVER_SIZE, std::string port_n = PORT, std::string ip_addr = IP_ADDR);
 
 
-  std::vector<std::pair<int, std::string>> p_insert {};
+  std::vector<std::pair<int, std::string>> p_insert_ {};
   int connect(void);
   int send(void);
   int receive(void);
+  void pr_ids(void);
 
 
 private:
-  int server_size;
-  std::vector<int> r_ids;
-  std::vector<std::string> names {"Alice", "Bob", "Eve", "Mallory"};
-  std::unique_ptr<Asio::tcp::socket> current_socket;
+  int server_size_;
+  std::vector<int> r_ids_;
+  std::vector<std::string> names_ {"Alice", "Bob", "Eve", "Mallory"};
+  std::unique_ptr<Asio::tcp::socket> current_socket_;
 
-  std::string port;
-  std::string ip;
-  void generate_ids(std::vector<int>& id) noexcept;
-  std::chrono::duration<double, std::milli> t_lapse;
+  std::string port_;
+  std::string ip_;
+  std::chrono::duration<double, std::milli> t_lapse_;
 
 
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -13,7 +13,7 @@ void client_thread(void)
 {
 	Client client;
 
-	if(client.connect()) {
+	if(client.connect() == 0) { // No errors
 		client.send();
 	}
 	else {


### PR DESCRIPTION
Por algun motivo mi repo ya no apuntaba al de @fgr1986, asi que he
tenido que clonarlo otra vez.

* generate_ids ha sido movido de ser una función que solo se llama una
  vez a una lambda. Siguiendo el consejo de los items 31 y 32 de [1],
  he usado "init capture" pasa pasar el miembro r_ids a la lambda.

He añadido la función auxiliar pr_ids() para asegurarme de que la lambda
modificaba efectivamente r_ids del cliente y no una copia local.

* for loops: He revisado los for loops en el código y concretamente el
  que @fgr1986 remarca en el issue resulta mas aparatoso el código
  dentro del bucle con range-for-loop que con la forma tradicional.

* Lo nombres de los miembros de la clase Client ahora cuentan con el
  sufijo "_" como en el resto del proyecto.

Signed-off-by: Daniel Perez de Andres <danielperezdeandres@gmail.com>